### PR TITLE
fix indentation of `deadCodeElim` pragma, error on current nim doc

### DIFF
--- a/nimcuda/cublas_api.nim
+++ b/nimcuda/cublas_api.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cublas.lib" & "\"".}

--- a/nimcuda/cuda_runtime_api.nim
+++ b/nimcuda/cuda_runtime_api.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cudart.lib" & "\"".}

--- a/nimcuda/cudnn.nim
+++ b/nimcuda/cudnn.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   #{.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cudnn.lib" & "\"".}

--- a/nimcuda/cufft.nim
+++ b/nimcuda/cufft.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cufft.lib" & "\"".}
@@ -18,13 +18,13 @@ import
   cuComplex, library_types
 
 ##  Copyright 2005-2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  The source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  The Licensed Deliverables contained herein are PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and are being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -33,7 +33,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  THEY ARE
@@ -48,7 +48,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -58,16 +58,16 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 ## !
-##  \file cufft.h  
-##  \brief Public header file for the NVIDIA CUDA FFT library (CUFFT)  
-## 
+##  \file cufft.h
+##  \brief Public header file for the NVIDIA CUDA FFT library (CUFFT)
+##
 
 ##  CUFFT API function return values
 
@@ -95,7 +95,7 @@ type
   cufftReal* = cfloat
   cufftDoubleReal* = cdouble
 
-##  cufftComplex is a single-precision, floating-point complex data type that 
+##  cufftComplex is a single-precision, floating-point complex data type that
 ##  consists of interleaved real and imaginary components.
 ##  cufftDoubleComplex is the double-precision equivalent.
 
@@ -130,9 +130,9 @@ type
 const
   CUFFT_COMPATIBILITY_DEFAULT* = CUFFT_COMPATIBILITY_FFTW_PADDING
 
-## 
+##
 ##  structure definition used by the shim between old and new APIs
-## 
+##
 
 const
   MAX_SHIM_RANK* = 3

--- a/nimcuda/curand.nim
+++ b/nimcuda/curand.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
     import os
     {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "curand.lib" & "\"".}

--- a/nimcuda/cusolverDn.nim
+++ b/nimcuda/cusolverDn.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
@@ -14,15 +14,15 @@ else:
 import
   cuComplex, cublas_api, cusolver_common
 
-## 
+##
 ##  Copyright 2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -31,7 +31,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -46,7 +46,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -56,22 +56,22 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 ##    cuSolverDN : Dense Linear Algebra Library
-## 
-## 
+##
+##
 
 when not defined(CUSOLVERDN_H):
   const
     CUSOLVERDN_H* = true
   type
     cusolverDnContext* = object
-    
+
   type
     cusolverDnHandle_t* = ptr cusolverDnContext
   proc cusolverDnCreate*(handle: ptr cusolverDnHandle_t): cusolverStatus_t {.cdecl,

--- a/nimcuda/cusolverRf.nim
+++ b/nimcuda/cusolverRf.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
@@ -14,15 +14,15 @@ else:
 import
   cuComplex, cusolver_common
 
-## 
+##
 ##  Copyright 1993-2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -31,7 +31,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -46,7 +46,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -56,12 +56,12 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 
 when not defined(CUSOLVERRF_H):
   const
@@ -101,7 +101,7 @@ when not defined(CUSOLVERRF_H):
   ##  Opaque structure holding CUSOLVERRF library common
   type
     cusolverRfCommon* = object
-    
+
   type
     cusolverRfHandle_t* = ptr cusolverRfCommon
   ##  CUSOLVERRF create (allocate memory) and destroy (free memory) in the handle
@@ -162,7 +162,7 @@ when not defined(CUSOLVERRF_H):
       cdecl, importc: "cusolverRfSetupDevice", dyn.}
     ##  Input (in the device memory)
     ##  Output
-  ##  CUSOLVERRF update the matrix values (assuming the reordering, pivoting 
+  ##  CUSOLVERRF update the matrix values (assuming the reordering, pivoting
   ##    and consequently the sparsity pattern of L and U did not change),
   ##    and zero out the remaining values.
   proc cusolverRfResetValues*(n: cint; nnzA: cint; csrRowPtrA: ptr cint;
@@ -219,7 +219,7 @@ when not defined(CUSOLVERRF_H):
       cdecl, importc: "cusolverRfBatchSetupHost", dyn.}
     ##  Input (in the host memory)
     ##  Output (in the device memory)
-  ##  CUSOLVERRF-batch update the matrix values (assuming the reordering, pivoting 
+  ##  CUSOLVERRF-batch update the matrix values (assuming the reordering, pivoting
   ##    and consequently the sparsity pattern of L and U did not change),
   ##    and zero out the remaining values.
   proc cusolverRfBatchResetValues*(batchSize: cint; n: cint; nnzA: cint;

--- a/nimcuda/cusolverSp.nim
+++ b/nimcuda/cusolverSp.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}

--- a/nimcuda/cusolver_common.nim
+++ b/nimcuda/cusolver_common.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "cusolver.lib" & "\"".}
@@ -14,15 +14,15 @@ else:
 import
   library_types
 
-## 
+##
 ##  Copyright 2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -31,7 +31,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -46,7 +46,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -56,12 +56,12 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 
 when not defined(CUSOLVER_COMMON_H):
   const

--- a/nimcuda/nvblas.nim
+++ b/nimcuda/nvblas.nim
@@ -1,4 +1,4 @@
- {.deadCodeElim: on.}
+{.deadCodeElim: on.}
 when defined(windows):
   import os
   {.passL: "\"" & os.getEnv("CUDA_PATH") / "lib/x64" / "nvblas.lib" & "\"".}
@@ -14,15 +14,15 @@ else:
 import
   cuComplex
 
-## 
+##
 ##  Copyright 1993-2014 NVIDIA Corporation.  All rights reserved.
-## 
+##
 ##  NOTICE TO LICENSEE:
-## 
+##
 ##  This source code and/or documentation ("Licensed Deliverables") are
 ##  subject to NVIDIA intellectual property rights under U.S. and
 ##  international Copyright laws.
-## 
+##
 ##  These Licensed Deliverables contained herein is PROPRIETARY and
 ##  CONFIDENTIAL to NVIDIA and is being provided under the terms and
 ##  conditions of a form of NVIDIA software license agreement by and
@@ -31,7 +31,7 @@ import
 ##  the contrary in the License Agreement, reproduction or disclosure
 ##  of the Licensed Deliverables to any third party without the express
 ##  written consent of NVIDIA is prohibited.
-## 
+##
 ##  NOTWITHSTANDING ANY TERMS OR CONDITIONS TO THE CONTRARY IN THE
 ##  LICENSE AGREEMENT, NVIDIA MAKES NO REPRESENTATION ABOUT THE
 ##  SUITABILITY OF THESE LICENSED DELIVERABLES FOR ANY PURPOSE.  IT IS
@@ -46,7 +46,7 @@ import
 ##  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ##  ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
 ##  OF THESE LICENSED DELIVERABLES.
-## 
+##
 ##  U.S. Government End Users.  These Licensed Deliverables are a
 ##  "commercial item" as that term is defined at 48 C.F.R. 2.101 (OCT
 ##  1995), consisting of "commercial computer software" and "commercial
@@ -56,12 +56,12 @@ import
 ##  48 C.F.R. 227.7202-1 through 227.7202-4 (JUNE 1995), all
 ##  U.S. Government End Users acquire the Licensed Deliverables with
 ##  only those rights set forth herein.
-## 
+##
 ##  Any use of the Licensed Deliverables in individual and commercial
 ##  software must include, in the user documentation and internal
 ##  comments to the code, the above Disclaimer and U.S. Government End
 ##  Users Notice.
-## 
+##
 
 when not defined(NVBLAS_H):
   const


### PR DESCRIPTION
This causes errors with modern nim doc.

Given that nimcuda still supports old nim versions where dead code
elimination may not be the default, I decided to keep it in.

edit: for reference, CI failure here: https://github.com/SciNim/Datamancer/runs/6686262839